### PR TITLE
Fix missing Composable import in FallingObjectsContainer

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/model/FallingObjectsContainer.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/model/FallingObjectsContainer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.widget.ImageView
 import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember


### PR DESCRIPTION
## Summary
- add the missing `Composable` import in `FallingObjectsContainer` so the annotation resolves correctly

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc802e776083288b65d543723c5bc0