### PR TITLE
Expand game background to fill the screen

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -48,16 +48,22 @@ class GameFragment : Fragment() {
     @Composable
     fun GameContent() {
         val context = LocalContext.current
-        val imageView = remember { ImageView(context) }
-        Glide.with(context)
-            .asGif()
-            .load(R.drawable.game_background)
-            .into(imageView)
+        val imageView = remember {
+            ImageView(context).apply {
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            }
+        }
 
-        AndroidView(
-            factory = { imageView },
-            modifier = Modifier.fillMaxSize()
-        )
+        LaunchedEffect(imageView) {
+            Glide.with(context)
+                .asGif()
+                .load(R.drawable.game_background)
+                .into(imageView)
+        }
 
         val characterPainter = painterResource(id = R.drawable.character)
         val character = remember { Character("JoannaPink", 100, characterPainter) }
@@ -126,31 +132,38 @@ class GameFragment : Fragment() {
             }
         }
 
-        FallingObjectsContainer(
-            objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
-            screenWidth = width,
-            screenHeight = height,
-            character = character,
-            onCollision = { obj, objOffsetX, objOffsetY -> handleCollision(obj, objOffsetX, objOffsetY) }
-        )
+        Box(modifier = Modifier.fillMaxSize()) {
+            AndroidView(
+                factory = { imageView },
+                modifier = Modifier.matchParentSize()
+            )
 
-        CharacterContainer(character, width, height)
+            FallingObjectsContainer(
+                objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
+                screenWidth = width,
+                screenHeight = height,
+                character = character,
+                onCollision = { obj, objOffsetX, objOffsetY -> handleCollision(obj, objOffsetX, objOffsetY) }
+            )
 
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+            CharacterContainer(character, width, height)
+
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
             ) {
-                Text(text = "Score: $score", fontSize = 24.sp, color = Color.White)
-                Spacer(modifier = Modifier.height(16.dp))
-                CustomProgressBar(
-                    progress = progress,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(20.dp)
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(text = "Score: $score", fontSize = 24.sp, color = Color.White)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    CustomProgressBar(
+                        progress = progress,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(20.dp)
+                    )
                 )
             }
         }


### PR DESCRIPTION
## Summary
- ensure the animated GIF background uses match-parent layout parameters and center-crop scaling
- render the background inside a Box so the rest of the UI overlays it correctly

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc82ff0624832881ffdf678e02ccb8