### PR TITLE
Remove cyan background from progress bar

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
@@ -1,4 +1,3 @@
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.runtime.Composable
@@ -15,8 +14,7 @@ fun CustomProgressBar(
         progress = progress,
         modifier = modifier
             .fillMaxWidth()
-            .height(8.dp)
-            .background(color = Color.Cyan) // Χρώμα φόντου της γραμμής προόδου
-
+            .height(8.dp),
+        backgroundColor = Color.Transparent
     )
 }


### PR DESCRIPTION
## Summary
- remove the hardcoded cyan background from the custom progress bar so the blue rectangle disappears

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc83a8b0d88328a2897e745dc2ca96