### PR TITLE
Fix GameFragment column closure

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -164,7 +164,7 @@ class GameFragment : Fragment() {
                             .fillMaxWidth()
                             .height(20.dp)
                     )
-                )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the erroneous closing parenthesis with a closing brace in the `Column` composable block
- ensure the layout structure is syntactically valid so the fragment compiles

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8493711083289637768ffef35db9