### PR TITLE
Ensure game background covers entire screen

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -48,16 +48,19 @@ class GameFragment : Fragment() {
     @Composable
     fun GameContent() {
         val context = LocalContext.current
-        val imageView = remember { ImageView(context) }
+        val imageView = remember {
+            ImageView(context).apply {
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            }
+        }
         Glide.with(context)
             .asGif()
             .load(R.drawable.game_background)
             .into(imageView)
-
-        AndroidView(
-            factory = { imageView },
-            modifier = Modifier.fillMaxSize()
-        )
 
         val characterPainter = painterResource(id = R.drawable.character)
         val character = remember { Character("JoannaPink", 100, characterPainter) }
@@ -126,22 +129,27 @@ class GameFragment : Fragment() {
             }
         }
 
-        FallingObjectsContainer(
-            objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
-            screenWidth = width,
-            screenHeight = height,
-            character = character,
-            onCollision = { obj, objOffsetX, objOffsetY -> handleCollision(obj, objOffsetX, objOffsetY) }
-        )
+        Box(modifier = Modifier.fillMaxSize()) {
+            AndroidView(
+                factory = { imageView },
+                modifier = Modifier.matchParentSize()
+            )
 
-        CharacterContainer(character, width, height)
+            FallingObjectsContainer(
+                objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
+                screenWidth = width,
+                screenHeight = height,
+                character = character,
+                onCollision = { obj, objOffsetX, objOffsetY -> handleCollision(obj, objOffsetX, objOffsetY) }
+            )
 
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.TopCenter
-        ) {
+            CharacterContainer(character, width, height)
+
             Column(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(text = "Score: $score", fontSize = 24.sp, color = Color.White)


### PR DESCRIPTION
## Summary
- Ρύθμισα το ImageView του φόντου να χρησιμοποιεί scaleType CENTER_CROP και LayoutParams match_parent ώστε το GIF να καλύπτει όλη την οθόνη.
- Τοποθέτησα όλο το game UI μέσα σε Box για να εμφανίζεται πάνω από το φόντο πλήρους οθόνης.

## Testing
- ./gradlew lint *(αποτυχία: δεν υπάρχει εγκατεστημένο Android SDK στο περιβάλλον του build)*

------
https://chatgpt.com/codex/tasks/task_e_68cc87714dc8832881831f8fd59b002d