### PR TITLE
Modernize score progress bar and adjust scoring logic

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
@@ -1,22 +1,65 @@
+package ioannapergamali.savejoannepink.view
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun CustomProgressBar(
-    progress: Float,
+    score: Int,
+    maxScore: Int,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Color.White.copy(alpha = 0.25f),
+    indicatorColors: List<Color> = listOf(Color(0xFF6A11CB), Color(0xFF2575FC)),
+    contentColor: Color = Color.White
 ) {
-    LinearProgressIndicator(
-        progress = progress,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(8.dp)
-            .background(color = Color.Cyan) // Χρώμα φόντου της γραμμής προόδου
-
+    val targetProgress = if (maxScore <= 0) 0f else (score.toFloat() / maxScore).coerceIn(0f, 1f)
+    val animatedProgress by animateFloatAsState(
+        targetValue = targetProgress,
+        animationSpec = tween(durationMillis = 600, easing = FastOutSlowInEasing),
+        label = "scoreProgress"
     )
+
+    Box(
+        modifier = modifier
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(24.dp),
+                clip = true
+            )
+            .background(backgroundColor)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(animatedProgress)
+                .background(
+                    brush = Brush.horizontalGradient(indicatorColors)
+                )
+        )
+
+        Text(
+            text = "$score",
+            modifier = Modifier.align(Alignment.Center),
+            color = contentColor,
+            fontWeight = FontWeight.Bold,
+            fontSize = 14.sp
+        )
+    }
 }

--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -1,6 +1,5 @@
 package ioannapergamali.savejoannepink.view
 
-import CustomProgressBar
 import android.content.Context
 import android.graphics.Rect
 import android.os.Build
@@ -88,9 +87,9 @@ class GameFragment : Fragment() {
             height = displayMetrics.heightPixels
         }
 
-        var score by remember { mutableStateOf(0) }
+        var score by remember { mutableStateOf(100) }
+        var maxScore by remember { mutableStateOf(100) }
         var wisdom by remember { mutableStateOf(character.getWisdom()) }
-        var progress by remember { mutableStateOf(0f) }
 
         fun handleCollision(obj: FallingObject, objOffsetX: Float, objOffsetY: Float) {
             Log.d("Collision", "handleCollision called for object: ${obj.name}")
@@ -112,15 +111,18 @@ class GameFragment : Fragment() {
                 when (obj.type) {
                     FallingObject.ObjectType.DAMAGE -> {
                         character.decreaseWisdom(10)
+                        score = (score - 10).coerceAtLeast(0)
                     }
                     FallingObject.ObjectType.WISDOM -> {
                         character.increaseWisdom(10)
                         score += 10
                     }
                 }
+                if (score > maxScore) {
+                    maxScore = score
+                }
                 wisdom = character.getWisdom()
-                progress = wisdom / 100f
-                Log.d("Collision", "Score: $score, Wisdom: $wisdom")
+                Log.d("Collision", "Score: $score, MaxScore: $maxScore, Wisdom: $wisdom")
 
                 // Mark the object as collected
                 obj.collected = true
@@ -155,10 +157,11 @@ class GameFragment : Fragment() {
                 Text(text = "Score: $score", fontSize = 24.sp, color = Color.White)
                 Spacer(modifier = Modifier.height(16.dp))
                 CustomProgressBar(
-                    progress = progress,
+                    score = score,
+                    maxScore = maxScore,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(20.dp)
+                        .height(24.dp)
                 )
             }
         }


### PR DESCRIPTION
## Summary
- replace the linear progress indicator with a custom animated gradient bar that displays the current score
- initialize the score at 100 and keep track of the maximum reached value to drive the progress animation
- update collision handling so wisdom pickups add 10 points, damage pickups subtract 10 points, and the UI reflects the new totals

## Testing
- `./gradlew lint` *(fails: Android SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8aabaf3c8328b9c8c3c9a5209026