### PR TITLE
Adjust score handling on collisions

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -108,16 +108,17 @@ class GameFragment : Fragment() {
 
             if (Rect.intersects(characterBounds, objectBounds)) {
                 Log.d("Collision", "Collision detected with object: ${obj.name}")
-                when (obj.type) {
+                val scoreDelta = when (obj.type) {
                     FallingObject.ObjectType.DAMAGE -> {
                         character.decreaseWisdom(10)
-                        score = (score - 10).coerceAtLeast(0)
+                        -10
                     }
                     FallingObject.ObjectType.WISDOM -> {
                         character.increaseWisdom(10)
-                        score += 10
+                        10
                     }
                 }
+                score = (score + scoreDelta).coerceAtLeast(0)
                 if (score > maxScore) {
                     maxScore = score
                 }


### PR DESCRIPTION
## Summary
- ensure the collision handler adjusts the score by ±10 based on the falling object type
- keep wisdom adjustments while preventing the score from dropping below zero

## Testing
- ./gradlew test *(fails: SDK location not found in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8c50a350832883eb1fe06da7cfc5