### PR TITLE
Fix parameter names in GameFragment collision handler

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -89,8 +89,8 @@ class GameFragment : Fragment() {
         var maxScore by remember { mutableStateOf(100) }
         var wisdom by remember { mutableStateOf(character.getWisdom()) }
 
-        fun handleCollision(obj: FallingObject, _: Float, _: Float) {
-            Log.d("Collision", "handleCollision called for object: ${obj.name}")
+        fun handleCollision(obj: FallingObject, offsetX: Float, offsetY: Float) {
+            Log.d("Collision", "handleCollision called for object: ${obj.name} at (${offsetX}, ${offsetY})")
 
             if (obj.collected) {
                 Log.d("Collision", "Object already collected, skipping score update")
@@ -130,7 +130,7 @@ class GameFragment : Fragment() {
                 screenWidth = width,
                 screenHeight = height,
                 character = character,
-                onCollision = { obj, objOffsetX, objOffsetY -> handleCollision(obj, objOffsetX, objOffsetY) }
+                onCollision = ::handleCollision
             )
 
             CharacterContainer(character, width, height)


### PR DESCRIPTION
## Summary
- rename the collision handler parameters to valid Kotlin identifiers and log their values
- pass the handler to the container using a function reference

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc900fbbf083289f89e52ab050ad91