### PR TITLE
Make falling items continuously respawn

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -91,14 +91,6 @@ class GameFragment : Fragment() {
 
         fun handleCollision(obj: FallingObject, offsetX: Float, offsetY: Float) {
             Log.d("Collision", "handleCollision called for object: ${obj.name} at (${offsetX}, ${offsetY})")
-
-            if (obj.collected) {
-                Log.d("Collision", "Object already collected, skipping score update")
-                return
-            }
-
-            obj.collected = true
-
             val scoreDelta = when (obj.type) {
                 FallingObject.ObjectType.DAMAGE -> {
                     character.decreaseWisdom(10)
@@ -107,7 +99,6 @@ class GameFragment : Fragment() {
                 FallingObject.ObjectType.WISDOM -> {
                     character.increaseWisdom(10)
                     10
-
                 }
             }
 
@@ -126,7 +117,7 @@ class GameFragment : Fragment() {
             )
 
             FallingObjectsContainer(
-                objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
+                objects = fallingObjects,
                 screenWidth = width,
                 screenHeight = height,
                 character = character,


### PR DESCRIPTION
## Summary
- keep falling objects inside the game loop so they respawn at the top after touching the character or leaving the screen
- update the score and character stats on collision without removing the items from the scene

## Testing
- ./gradlew lint *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca0103f7883288d750048da5fee5b