### PR TITLE
Fix falling object collision height

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/model/FallingObjectsContainer.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/model/FallingObjectsContainer.kt
@@ -180,7 +180,11 @@ fun checkCollision(
     objOffsetY: Float
 ): Boolean {
     val charX = character.offsetX
-    val charY = 520f // Fixed Y position of the character
+    val charY = character.currentYPosition
+
+    if (charY <= 0f) {
+        return false
+    }
     val charWidth = character.getCharacterWidth()
     val charHeight = character.getCharacterHeight()
     val objWidth = obj.getObjectWidth(context)


### PR DESCRIPTION
## Summary
- use the character's current Y position when checking collisions with falling objects
- prevent premature collision detection before the character has been positioned on screen

## Testing
- ./gradlew test *(fails: SDK location not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bc00341c83288f79064fca9197c7