### PR TITLE
Modernize the custom progress bar

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/CustomProgressBar.kt
@@ -1,8 +1,19 @@
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
@@ -11,12 +22,51 @@ fun CustomProgressBar(
     progress: Float,
     modifier: Modifier = Modifier,
 ) {
-    LinearProgressIndicator(
-        progress = progress,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(8.dp)
-            .background(color = Color.Cyan) // Χρώμα φόντου της γραμμής προόδου
-
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    val animatedProgress by animateFloatAsState(
+        targetValue = clampedProgress,
+        animationSpec = tween(durationMillis = 600, easing = FastOutSlowInEasing),
+        label = "progressAnimation"
     )
+
+    val shape = RoundedCornerShape(percent = 50)
+    val trackColor = Color(0xFF0F172A).copy(alpha = 0.6f)
+    val indicatorBrush = Brush.horizontalGradient(
+        colors = listOf(
+            Color(0xFF7F5AF0),
+            Color(0xFF2CB1BC),
+            Color(0xFF61E8E1)
+        )
+    )
+
+    Box(
+        modifier = modifier
+            .heightIn(min = 12.dp)
+            .clip(shape)
+            .background(trackColor)
+            .border(width = 1.dp, color = Color.White.copy(alpha = 0.12f), shape = shape)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(animatedProgress)
+                .fillMaxHeight()
+                .clip(shape)
+                .background(indicatorBrush)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.45f)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.White.copy(alpha = 0.3f),
+                                Color.Transparent
+                            )
+                        )
+                    )
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace the basic `LinearProgressIndicator` with an animated custom Compose bar
- add gradient fill, rounded corners, and subtle border/highlight for a modern look

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d406d87fa48328b92f8bf3a1a29031