### PR TITLE
Fix collision handling to update score and respawn objects

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -103,11 +103,10 @@ class GameFragment : Fragment() {
             }
         }
 
-        fun handleCollision(obj: FallingObject, objOffsetX: Float, objOffsetY: Float) {
+        fun handleCollision(obj: FallingObject, _: Float, _: Float) {
             Log.d("Collision", "handleCollision called for object: ${obj.name}")
 
-            // Skip already collected objects
-            if (obj.collected || gameState != GameState.RUNNING) {
+            if (gameState != GameState.RUNNING) {
                 return
             }
 
@@ -131,9 +130,6 @@ class GameFragment : Fragment() {
                     }
                 }
                 Log.d("Collision", "Score: $score")
-
-                // Mark the object as collected
-                obj.collected = true
             } else {
                 Log.d("Collision", "No collision detected")
             }
@@ -159,7 +155,7 @@ class GameFragment : Fragment() {
 
             if (gameState == GameState.RUNNING) {
                 FallingObjectsContainer(
-                    objects = fallingObjects.filter { !it.collected }, // Filter out collected objects here
+                    objects = fallingObjects,
                     screenWidth = width,
                     screenHeight = height,
                     character = character,


### PR DESCRIPTION
## Summary
- track falling object offsets with Compose state lists and reset them when they collide with the character or exit the screen
- update GameFragment collision handling so the score changes and respawn logic can run without filtering out collected objects
- add a helper to re-position falling objects at the top edge while preserving horizontal spacing

## Testing
- ./gradlew lintDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d41a6207d08328a0735226e3e1cf39