### PR TITLE
Fix collision handler parameter names

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -103,8 +103,11 @@ class GameFragment : Fragment() {
             }
         }
 
-        fun handleCollision(obj: FallingObject, _: Float, _: Float) {
-            Log.d("Collision", "handleCollision called for object: ${obj.name}")
+        fun handleCollision(obj: FallingObject, offsetX: Float, offsetY: Float) {
+            Log.d(
+                "Collision",
+                "handleCollision called for object: ${obj.name} at offsets x=$offsetX, y=$offsetY"
+            )
 
             if (gameState != GameState.RUNNING) {
                 return


### PR DESCRIPTION
## Summary
- rename the collision callback parameters in `GameFragment` to avoid using reserved underscore identifiers
- log the provided offsets when collisions are handled for better traceability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42153d8b08328af620d34a88d65e4